### PR TITLE
Update css to center connection-parameters displayed in the prompt

### DIFF
--- a/guacamole/src/main/webapp/app/prompt/styles/prompt.css
+++ b/guacamole/src/main/webapp/app/prompt/styles/prompt.css
@@ -70,6 +70,13 @@
     width: 100%;
 }
 
+.prompt .connection-parameters .form .fields {
+    padding-left: 0;
+    border-left: none;
+    width: unset;
+    margin: auto;
+}
+
 .prompt .title-bar {
     font-size: 1.25em;
     font-weight: bold;


### PR DESCRIPTION
Moved the CSS override to the prompt.css file since it is an override only meant for the prompts.